### PR TITLE
Fix command to install fontforge

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Here's the end result!
 2. Install fontforge using apt
 
     ```console
-    sudo apt-get install potrace
+    sudo apt-get install fontforge
     ```
 
 3. Clone the repository or your fork


### PR DESCRIPTION
The apt-get command to install fontforge was incorrect, fix it.